### PR TITLE
Fix logic for not-yet-valid certificates

### DIFF
--- a/greenpass/logic.py
+++ b/greenpass/logic.py
@@ -294,8 +294,7 @@ class LogicManager(object):
         if hours_to_valid != None and remaining_hours != None:
             if hours_to_valid < 0:
                 level = 3
-                remaining_hours = output.get_not_yet_valid(hours_to_valid)
-                remaining_days = output.get_not_yet_valid(hours_to_valid)
+                remaining_days = output.get_not_yet_valid(-hours_to_valid)
                 expired = True
             elif remaining_hours <= 0:
                 level = 3

--- a/greenpass/output.py
+++ b/greenpass/output.py
@@ -132,7 +132,7 @@ class OutputManager(NoneOutput):
             self.colored(remaining_days, color)
         )
 
-    def get_not_yet_valid(self, remaining_hours):
+    def get_not_yet_valid(self, hours_to_valid):
         return "Not yet valid, {:.0f} hours to validity, {} days".format(
                 hours_to_valid, int(hours_to_valid / 24)
         )


### PR DESCRIPTION
- Rename the variable, otherwise the code won't work at all.
- Add `-`, otherwise the reported time will be negative.
- Remove assignment to `remaining_hours`, because it is not used.