### PR TITLE
Fallback to English when locale cannot be determined

### DIFF
--- a/greenpass.py
+++ b/greenpass.py
@@ -174,10 +174,12 @@ def get_filetype(args):
     return (path, filetype)
 
 
-def get_language(lang):
-    if lang is None:
+def get_language():
+    loc = locale.getdefaultlocale()[0]
+    if loc is None:
+        # Fallback to English
         return "en"
-    return lang.split("_")[0]
+    return loc.split("_")[0]
 
 
 def main():
@@ -190,7 +192,7 @@ def main():
 
     sm = SettingsManager(cachedir, args.recovery_expiration)
 
-    language = get_language(locale.getdefaultlocale()[0])
+    language = get_language()
     if args.language is not None:
         language = args.language
 

--- a/greenpass.py
+++ b/greenpass.py
@@ -175,6 +175,8 @@ def get_filetype(args):
 
 
 def get_language(lang):
+    if lang is None:
+        return "en"
     return lang.split("_")[0]
 
 

--- a/greenpass.py
+++ b/greenpass.py
@@ -192,9 +192,7 @@ def main():
 
     sm = SettingsManager(cachedir, args.recovery_expiration)
 
-    language = get_language()
-    if args.language is not None:
-        language = args.language
+    language = get_language() if args.language is None else args.language
 
     if args.at_date is not None:
         sm.set_at_date(args.at_date)


### PR DESCRIPTION
Fix for issue #43: when the `locale.getdefaultlocale()` fails to retrieve the locale from environment value, fallback to English.
I also made minimal code changes to enhance readability.

P.S. Bel progettino! Ciao Dave :D